### PR TITLE
V1.1

### DIFF
--- a/NCommon/src/Events/DomainEvent.cs
+++ b/NCommon/src/Events/DomainEvent.cs
@@ -64,11 +64,13 @@ namespace NCommon.Events
         ///<typeparam name="T">A type implementing <see cref="IDomainEvent"/></typeparam>
         public static void Raise<T>(T @event) where T : IDomainEvent
         {
-            var state = ServiceLocator.Current.GetInstance<IState>();
             var handlers = ServiceLocator.Current.GetAllInstances<Handles<T>>();
             if (handlers != null)
                 handlers.ForEach(x => x.Handle(@event));
 
+            var state = ServiceLocator.Current.GetInstance<IState>();
+            if (state == null)
+                return;
             var callbacks = state.Local.Get<IList<Delegate>>(CallbackListKey);
             if (callbacks != null && callbacks.Count > 0)
                 callbacks.OfType<Action<T>>().ForEach(x => x(@event));


### PR DESCRIPTION
Before this change unit testing methods that raise a domain event requires mocking the service locator call to get and instance of IState and the subsequent call to state.Local.Get&lt;IList&lt;Delegate>>.  This is obtrusive and adds no value.

(By the way, I'm not sure why Git wants to replace the whole file.  I'm a Git noob, and could not figure out how get it to replace just the affected lines.)  :)
