### PR TITLE
V1.2 NCommon without ServiceLocator

### DIFF
--- a/NCommon.Db4o/src/Db4oRepository.cs
+++ b/NCommon.Db4o/src/Db4oRepository.cs
@@ -37,14 +37,22 @@ namespace NCommon.Data.Db4o
         /// </summary>
         public Db4oRepository()
         {
+            Initialize();
+        }
+        
+        /// <summary>
+        /// Default Init.
+        /// </summary>
+        protected virtual void Initialize()
+        {
             if (ServiceLocator.Current != null)
             {
                 var containers = ServiceLocator.Current.GetAllInstances<IObjectContainer>();
                 if (containers != null && containers.Count() > 0)
                     _privateContainer = containers.FirstOrDefault();
             }
-            
-        }
+        
+        }         
 
         /// <summary>
         /// Gets the <see cref="IObjectContainer"/> instance that is used by the repository.

--- a/NCommon.EntityFramework/src/EFRepository.cs
+++ b/NCommon.EntityFramework/src/EFRepository.cs
@@ -41,13 +41,22 @@ namespace NCommon.Data.EntityFramework
         /// </summary>
         public EFRepository()
         {
-            if (ServiceLocator.Current == null) 
+           Initialize();
+        }
+        
+        
+        /// <summary>
+        /// Default Init.
+        /// </summary>
+        protected virtual void Initialize()
+        {
+             if (ServiceLocator.Current == null) 
                 return;
 
             var sessions = ServiceLocator.Current.GetAllInstances<IEFSession>();
             if (sessions != null && sessions.Count() > 0)
                 _privateSession = sessions.First();
-        }
+        }        
 
         /// <summary>
         /// Gets the <see cref="ObjectContext"/> to be used by the repository.

--- a/NCommon.LinqToSql/src/LinqToSqlRepository.cs
+++ b/NCommon.LinqToSql/src/LinqToSqlRepository.cs
@@ -38,12 +38,20 @@ namespace NCommon.Data.LinqToSql
         /// </summary>
         public LinqToSqlRepository()
         {
+            Initialize()
+        }
+        
+        /// <summary>
+        /// Default Init.
+        /// </summary>
+        protected virtual void Initialize()
+        {
             if (ServiceLocator.Current == null)
                 return;
 
             var sessions = ServiceLocator.Current.GetAllInstances<ILinqToSqlSession>();
             if (sessions != null && sessions.Count() > 0)
-                _privateSession = sessions.FirstOrDefault();
+                _privateSession = sessions.FirstOrDefault();        
         }
 
         /// <summary>

--- a/NCommon.LinqToSql/src/LinqToSqlRepository.cs
+++ b/NCommon.LinqToSql/src/LinqToSqlRepository.cs
@@ -38,7 +38,7 @@ namespace NCommon.Data.LinqToSql
         /// </summary>
         public LinqToSqlRepository()
         {
-            Initialize()
+            Initialize();
         }
         
         /// <summary>

--- a/NCommon.NHibernate/src/NHRepository.cs
+++ b/NCommon.NHibernate/src/NHRepository.cs
@@ -41,13 +41,21 @@ namespace NCommon.Data.NHibernate
         /// </summary>
         public NHRepository ()
         {
+            Initialize();           
+        }
+        
+         /// <summary>
+        /// Default Init.
+        /// </summary>
+        protected virtual void Initialize()
+        {
             if (ServiceLocator.Current == null)
                 return;
 
             var sessions = ServiceLocator.Current.GetAllInstances<ISession>();
             if (sessions != null && sessions.Count() > 0)
                 _privateSession = sessions.FirstOrDefault();
-        }
+        }         
 
         /// <summary>
         /// Gets the <see cref="ISession"/> instnace that is used by the repository.

--- a/NCommon/src/Data/RepositoryBase.cs
+++ b/NCommon/src/Data/RepositoryBase.cs
@@ -170,7 +170,7 @@ namespace NCommon.Data
         /// Implementors should perform context specific actions within this method call and return
         /// the exact same instance.
         /// </remarks>
-        public IQueryable<TEntity> For<TService>()
+        public virtual IQueryable<TEntity> For<TService>()
         {
             var strategy = ServiceLocator
                 .Current


### PR DESCRIPTION
Hey!
We try to use NCommon for our project but we have a several composition root. Therefore we can't to define a global ServiceLocator. I 've found that It's possible to override UnitOfWorkScope, TransactionManager and LinqToSqlRepository to replace ServiceLocator.Current on IUnityContainer. But LinqToSqlRepository (and other) have a bad dependency in constructor, although there is a check ServiceLocator.Current !=null (btw throw exception if ServiceLocator isn't set ) but It'll have risk that somebody set once. I offer to add a several virtual methods to clear NCommon.
